### PR TITLE
Replicate spacing tolerance from 'locals' to 'triggerSitemapBuilder'

### DIFF
--- a/blueprints/sitemap-autogenerator/index.js
+++ b/blueprints/sitemap-autogenerator/index.js
@@ -19,7 +19,8 @@ module.exports = {
     fs.readFile(pathForRouterJS, 'utf8', function (err, data) {
       if (err) return console.log('Encountered the following error:', err);
 
-      data = data.split('Router.map(function() {')[1]; // Split file text into code lines by 'Router.map', resulting in two code chunks --> choose the chunk after 'Router.map'
+      let splitBy = /Router.map\(\s*function\s*\(\)\s*\{/; // Provision for variations in spacing for this line
+      data = data.split(splitBy)[1]; // Split file text into code lines by 'Router.map', resulting in two code chunks --> choose the chunk after 'Router.map'
 
       splitDataIntoArrayOfRoutes(data);
       findEndOfCodeBlock(data);


### PR DESCRIPTION
A provision for variations in spacing within the `Router.map( function() {` marker was added in fecd98528e85d25f12a2544eb1a3747a053af50f, but only to the `locals` function.  This PR adds this same spacing tolerance to the `triggerSitemapBuilder` function.

This should fix the build error referenced in https://github.com/wackerservices/Typenex/pull/220.